### PR TITLE
feat: add loyalty levels and improve stock view

### DIFF
--- a/bot/utils/level.py
+++ b/bot/utils/level.py
@@ -1,0 +1,31 @@
+LEVEL_NAMES = [
+    "Apartamentų lankytojas",
+    "Apartamentų mėgėjas",
+    "Apartamentų fanas",
+    "Apartamentų liūtas",
+    "Apartamentų vairuotojas",
+    "Apartamentų apsauga",
+    "Apartamentų VIP'as",
+    "Apartamentų vadovas",
+    "Apartamentų dešinė ranka",
+    "Apartamentų valdžia",
+]
+
+
+def get_level_info(purchases: int):
+    """Return level details for given purchase count.
+
+    Returns tuple of (level_name, discount_percent, progress_bar, battery_emoji).
+    """
+    if purchases < 0:
+        purchases = 0
+    # determine level index (0-9)
+    level_index = min(purchases // 10, len(LEVEL_NAMES) - 1)
+    level_name = LEVEL_NAMES[level_index]
+    discount = round((level_index + 1) * 1.2, 1)
+    progress = purchases % 10
+    segment = progress // 5  # 0 or 1
+    battery = "🪫" if segment == 0 else "🔋"
+    bars_filled = progress % 5
+    progress_bar = "🟩" * bars_filled + "⬜️" * (5 - bars_filled)
+    return level_name, discount, progress_bar, battery


### PR DESCRIPTION
## Summary
- display loyalty level status in main menu and apply level-based discounts
- notify users on level-up and include detailed purchase info for owner
- show stock counts and descriptions when viewing admin stock

## Testing
- `pytest`
- `python -m py_compile bot/utils/level.py bot/handlers/user/main.py bot/handlers/admin/view_stock.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4d01591488332b5beef569cfce72e